### PR TITLE
fix: change shapefile encoding from latin1 to utf8

### DIFF
--- a/licenses/src/config.mjs
+++ b/licenses/src/config.mjs
@@ -41,7 +41,7 @@ export const license = {
    unziped_folder: '',
    shapefile: `BRASIL.shp`,
    dbf: `BRASIL.dbf`,
-   encoding: 'latin1',
+   encoding: 'utf8',
    properties: [
       'PROCESSO',
       'ID',


### PR DESCRIPTION
# Accented Portuguese characters display as mojibake on the map popup and data fields.

## Examples

| Displayed | Expected |
|---|---|
| AUTORIZAÃ§Ã£O DE PESQUISA | AUTORIZAÇÃO DE PESQUISA |
| MINÃ%RIO DE COBRE | MINÉRIO DE COBRE |
| RESOLUÃ§Ã£O | RESOLUÇÃO |

## Root Cause

The ANM shapefile (`BRASIL.dbf`) contains UTF-8 encoded text, but the application reads it with `encoding: 'latin1'` (`src/config.mjs`, line 44). This causes **double-encoding**: UTF-8 multi-byte characters (e.g., `ç` = bytes `C3 A7`) are interpreted as two Latin-1 characters (`Ã§`), then re-encoded to UTF-8 when stored.

## Affected Data

The corrupted text propagates through the entire pipeline:

1. **MongoDB** - all license, invasion, and reserve invasion collections
2. **Mapbox tilesets** - `am_minada_requerimentos`, `am_minada_requerimentos_ti`, `am_minada_unidades_conservacao`, `am_minada_terras_indigenas`
3. **Output files** - GeoJSON and CSV files under `files/`

## Screenshots

before:
<img width="611" height="710" alt="Screenshot 2026-03-10 at 16 09 39" src="https://github.com/user-attachments/assets/5e455354-3d9c-496e-a5cb-8d5feb9d008a" />

after:
<img width="697" height="665" alt="Screenshot 2026-03-10 at 16 10 02" src="https://github.com/user-attachments/assets/33cd2a56-6987-48bc-97ee-c46155af6501" />

## Next Steps
This fix only affects new data reads. Existing corrupted data in MongoDB and Mapbox tilesets requires a full re-seed (node src/seeds.mjs) with a write-capable MAPBOX_ACCESS_TOKEN to propagate the fix.
  
Fixes #16 